### PR TITLE
Search for end of frame from front to back

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -293,4 +293,22 @@ mod tests {
             _ => panic!("Error decoding second message"),
         }
     }
+    #[test]
+    fn test_parsing_multiple_messages() {
+        let mut mllp = MllpCodec::new();
+        let mut data = wrap_for_mllp_mut("MSH|^~\\&|ZIS|1^AHospital|||200405141144||¶ADT^A01|20041104082400|P|2.3|||AL|NE|||8859/15|¶EVN|A01|20041104082400.0000+0100|20041104082400¶PID||\"\"|10||Vries^Danny^D.^^de||19951202|M|||Rembrandlaan^7^Leiden^^7301TH^\"\"^^P||\"\"|\"\"||\"\"|||||||\"\"|\"\"¶PV1||I|3w^301^\"\"^01|S|||100^van den Berg^^A.S.^^\"\"^dr|\"\"||9||||H||||20041104082400.0000+0100");
+        let bytes = data.clone().iter().map(|s| s.to_owned()).collect::<Vec<u8>>();
+        data.extend_from_slice(&bytes[..]);
+        data.extend_from_slice(&bytes[..]);
+        let result = mllp.decode(&mut data);
+        match result {
+            Ok(Some(message)) => {
+                // Ensure that a single message was parsed out correctly
+                assert_eq!(message.len(), 338);
+                // Check to make sure data is two messages and two encapsulations in size
+                assert_eq!(data.len(), (message.len() * 2) + 6);
+            }
+            _ => assert!(false),
+        }
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -300,6 +300,7 @@ mod tests {
         let bytes = data.clone().iter().map(|s| s.to_owned()).collect::<Vec<u8>>();
         data.extend_from_slice(&bytes[..]);
         data.extend_from_slice(&bytes[..]);
+        // Read first message
         let result = mllp.decode(&mut data);
         match result {
             Ok(Some(message)) => {
@@ -307,6 +308,17 @@ mod tests {
                 assert_eq!(message.len(), 338);
                 // Check to make sure data is two messages and two encapsulations in size
                 assert_eq!(data.len(), (message.len() * 2) + 6);
+            }
+            _ => assert!(false),
+        }
+        // Read second message
+        let result = mllp.decode(&mut data);
+        match result {
+            Ok(Some(message)) => {
+                // Ensure that a single message was parsed out correctly
+                assert_eq!(message.len(), 338);
+                // Check to make sure remaining data is the size of the message and encap
+                assert_eq!(data.len(), message.len() + 3);
             }
             _ => assert!(false),
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,21 +69,19 @@ impl MllpCodec {
     }
 
     fn get_footer_position(src: &BytesMut) -> Option<usize> {
-        let mut iter = src.iter().rev().enumerate().peekable(); //search from end (footer should be right at the end)
+        let mut iter = src.iter().enumerate().peekable(); //search from start because we may have multiple messages on socket
         loop {
             let cur = iter.next();
             let next = iter.peek();
 
             match (cur, next) {
-                (Some((_, cur_ele)), Some((i, next_ele))) => {
+                (Some((i, cur_ele)), Some((_, next_ele))) => {
                     //both current and next ele are avail
-                    if cur_ele == &MllpCodec::BLOCK_FOOTER[1]
-                        && *next_ele == &MllpCodec::BLOCK_FOOTER[0]
+                    if cur_ele == &MllpCodec::BLOCK_FOOTER[0]
+                        && *next_ele == &MllpCodec::BLOCK_FOOTER[1]
                     {
-                        //if the bytes are our footer
-                        let index = src.len() - i - 1; //need an extra byte removed
-                        trace!("MLLP: Found footer at index {}", index);
-                        return Some(index);
+                        trace!("MLLP: Found footer at index {}", i);
+                        return Some(i);
                     }
                 }
                 (_, None) => {


### PR DESCRIPTION
MLLP senders do not necessarily wait for an ACK to send more MLLP
messages, meaning that the semantic of searching for the end of the
message at the end of the current TCP socket buffer allows a "frame"
to contain more than one message so long as the start and end bytes
of the stack of messages are correct.

Rewire the search loop to search front-to-back, which will mean
iterating all bytes on the socket in cases where sender requires
an ACK before sending more messages, but will work for asynchronous
transports which do not require or simply ignore the ACK. This
ensures semantically correct parsing, at the expense of more stream
processing in the iterator.