### PR TITLE
Feat/noncompliance

### DIFF
--- a/.github/workflows/CI Ubuntu.yml
+++ b/.github/workflows/CI Ubuntu.yml
@@ -14,5 +14,9 @@ jobs:
     - uses: actions/checkout@v2
     - name: Build
       run: cargo build --verbose
-    - name: Run tests
+      
+    - name: Run tests (spec-compliant)
       run: cargo test --verbose
+
+    - name: Run tests (noncompliant feature)
+      run: cargo test --verbose --features noncompliance

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,9 @@ include = [
     "Cargo.toml",
 ]
 
-# [profile.release]
-# debug = true # Flamegraph love
+[features]
+# Enables non-spec compliant behaviours, because why follow a standard built around interoperability... :(
+noncompliance = []
 
 [dependencies]
 bytes = "1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -293,4 +293,22 @@ mod tests {
             _ => panic!("Error decoding second message"),
         }
     }
+    #[test]
+    fn test_parsing_multiple_messages() {
+        let mut mllp = MllpCodec::new();
+        let mut data = wrap_for_mllp_mut("MSH|^~\\&|ZIS|1^AHospital|||200405141144||¶ADT^A01|20041104082400|P|2.3|||AL|NE|||8859/15|¶EVN|A01|20041104082400.0000+0100|20041104082400¶PID||\"\"|10||Vries^Danny^D.^^de||19951202|M|||Rembrandlaan^7^Leiden^^7301TH^\"\"^^P||\"\"|\"\"||\"\"|||||||\"\"|\"\"¶PV1||I|3w^301^\"\"^01|S|||100^van den Berg^^A.S.^^\"\"^dr|\"\"||9||||H||||20041104082400.0000+0100");
+        let bytes = data.clone().iter().map(|s| s.to_owned()).collect::<Vec<u8>>();
+        data.extend_from_slice(&bytes[..]);
+        data.extend_from_slice(&bytes[..]);
+        let result = mllp.decode(&mut data);
+        match result {
+            Ok(Some(message)) => {
+                // Ensure that a single message was parsed out correctly
+                assert_eq!(message.len(), 338);
+                // Check to make sure data is two messages and two encapsulations in size
+                assert_eq!(data.len(), (message.len() * 2) + 6);
+            }
+            _ => assert!(false),
+        }
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -300,6 +300,7 @@ mod tests {
         let bytes = data.clone().iter().map(|s| s.to_owned()).collect::<Vec<u8>>();
         data.extend_from_slice(&bytes[..]);
         data.extend_from_slice(&bytes[..]);
+        // Read first message
         let result = mllp.decode(&mut data);
         match result {
             Ok(Some(message)) => {
@@ -307,6 +308,17 @@ mod tests {
                 assert_eq!(message.len(), 338);
                 // Check to make sure data is two messages and two encapsulations in size
                 assert_eq!(data.len(), (message.len() * 2) + 6);
+            }
+            _ => assert!(false),
+        }
+        // Read second message
+        let result = mllp.decode(&mut data);
+        match result {
+            Ok(Some(message)) => {
+                // Ensure that a single message was parsed out correctly
+                assert_eq!(message.len(), 338);
+                // Check to make sure remaining data is the size of the message and encap
+                assert_eq!(data.len(), message.len() + 3);
             }
             _ => assert!(false),
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,21 +69,19 @@ impl MllpCodec {
     }
 
     fn get_footer_position(src: &BytesMut) -> Option<usize> {
-        let mut iter = src.iter().rev().enumerate().peekable(); //search from end (footer should be right at the end)
+        let mut iter = src.iter().enumerate().peekable(); //search from start because we may have multiple messages on socket
         loop {
             let cur = iter.next();
             let next = iter.peek();
 
             match (cur, next) {
-                (Some((_, cur_ele)), Some((i, next_ele))) => {
+                (Some((i, cur_ele)), Some((_, next_ele))) => {
                     //both current and next ele are avail
-                    if cur_ele == &MllpCodec::BLOCK_FOOTER[1]
-                        && *next_ele == &MllpCodec::BLOCK_FOOTER[0]
+                    if cur_ele == &MllpCodec::BLOCK_FOOTER[0]
+                        && *next_ele == &MllpCodec::BLOCK_FOOTER[1]
                     {
-                        //if the bytes are our footer
-                        let index = src.len() - i - 1; //need an extra byte removed
-                        trace!("MLLP: Found footer at index {}", index);
-                        return Some(index);
+                        trace!("MLLP: Found footer at index {}", i);
+                        return Some(i);
                     }
                 }
                 (_, None) => {


### PR DESCRIPTION
First cut at an opt-in feature to enable support for data streams that don't _actually_ meet the MLL spec.  This should help #2 at the cost of extra docco, another dimension to builds/tests (added to the CI action) and more things to mentally juggle when making other changes.

@sempervictus: Can you cast your eye over this and let me know if there's anything else you'd like before I merge to master and push a new version to crates.io?