### PR TITLE
Feat #4: Allow messages to be split over multiple calls to `decode()`

### DIFF
--- a/examples/cargo.toml
+++ b/examples/cargo.toml
@@ -5,5 +5,5 @@ publish = false
 edition = "2018"
 
 [dev-dependencies]
-hl7-mllp-codec = {version ="0.1.0" path="../src/lib.rs"}
-tokio = "0.2"
+hl7-mllp-codec = {version ="0.2" path="../src/lib.rs"}
+tokio = "1.9"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -184,18 +184,18 @@ impl Decoder for MllpCodec {
             decode_internal(&mut self.buffer)
         };
 
-       match result {
-        Ok(None) if self.buffer.len() == 0 => { //if there's already data in the buffer we concatted it above, no need to do so again
-            // if here we need to concat the src buffer locally for future calls...
+       
+        if let Ok(None) = result { // we didn't find a message
+            if self.buffer.len() == 0 { // if there's already data in the buffer we concatted it above, no need to do so again
+                    // if here we need to concat the src buffer locally for future calls...
 
-            self.buffer.reserve(src.len());
-            self.buffer.put_slice(src);
-            src.advance(src.len()); // this consumes the whole src buffer and keeps tokio happy, but breaks the non-compliant variant that can have multiple messages in the buffer
-        },
-        _ => return result //Error or Ok(Some(result))
-       }
+                    self.buffer.reserve(src.len());
+                    self.buffer.put_slice(src);
+                    src.advance(src.len()); // this consumes the whole src buffer and keeps tokio happy, but breaks the non-compliant variant that can have multiple messages in the buffer
+            }
+        }
 
-       Ok(None) // no message lurking in here yet
+        result
     }
 }
 


### PR DESCRIPTION
Buffer content if we don't get a full message, and concat on the next call until we _do_ get a full message.