### PR TITLE
update tokio-util to version 7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hl7-mllp-codec"
 description = "A Tokio codec for HL7 Minimal Lower Layer Message Transport protocol (MLLP)"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["wokket <wokket@gmail.com>"]
 edition = "2018"
 license = "MIT"
@@ -21,7 +21,7 @@ noncompliance = []
 
 [dependencies]
 bytes = "1"
-tokio-util = {version="0.6.7", features=["codec"]}
+tokio-util = {version="0.7.3", features=["codec"]}
 log = "0.4"
 
 [dev-dependencies]


### PR DESCRIPTION
Hi, I've update the dependency on tokio-util from version 0.6.7. to version 0.7.3. tokio-util is exposed in the public api so I've also updated the crate's own version to 0.4.0, but I don't know if that is what you want. 

If you have any questions, please let me know...
